### PR TITLE
Update main.py for py 2.7 compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,13 +13,13 @@ except ImportError:
 
 def center_pad(s, length):
     num_dashes = float(length - len(s) - 2) / 2
-    num_dashes_left = math.floor(num_dashes)
-    num_dashes_right = math.ceil(num_dashes)
+    num_dashes_left = int(math.floor(num_dashes))
+    num_dashes_right = int(math.ceil(num_dashes))
 
     return ('=' * num_dashes_left) + ' ' + s + ' ' + ('=' * num_dashes_right)
 
 def two_column_with_period(left, right, length):
-    num_periods = (length - (len(left) + len(right) + 2))
+    num_periods = int(length - (len(left) + len(right) + 2))
     return left + ' ' + ('.' * num_periods) + ' ' + right
 
 def usage(argv):


### PR DESCRIPTION
I fixed a little bug for python 2.7.
num_dashes/periods contained floats, which lead to a 'string' \* float(x)  scenario which isn't good, is it ?
So i parsed them to ints.
