### PR TITLE
Removed errant comma

### DIFF
--- a/imgurpython/imgur/models/account.py
+++ b/imgurpython/imgur/models/account.py
@@ -5,5 +5,5 @@ class Account:
         self.url = url
         self.bio = bio
         self.reputation = reputation
-        self.created = created,
+        self.created = created
         self.pro_expiration = pro_expiration


### PR DESCRIPTION
`self.created = created,` builds a tuple in `self.created`. This appears to be a mistake. See below for an example:

``` python
>>> x = 3,
>>> x
(3,)
```
