### PR TITLE
added import for ImgurClientError in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Error types
 * ImgurClientError - General error handler, access message and status code via
 
 ```python
+from imgurpython.helpers.error import ImgurClientError
+
 try
     ...
 except ImgurClientError as e


### PR DESCRIPTION
Added the right import needed to be able to catch exception. Which module to import isn't obvious as it is burried in helpers.error.
