### PR TITLE
Add parameter reason for method report_gallery_item

### DIFF
--- a/imgurpython/client.py
+++ b/imgurpython/client.py
@@ -552,9 +552,9 @@ class ImgurClient(object):
         response = self.make_request('GET', 'gallery/%s' % item_id)
         return build_gallery_images_and_albums(response)
 
-    def report_gallery_item(self, item_id):
+    def report_gallery_item(self, item_id, reason):
         self.logged_in()
-        return self.make_request('POST', 'gallery/%s/report' % item_id)
+        return self.make_request('POST', 'gallery/%s/report' % item_id, {'reason': reason})
 
     def gallery_item_vote(self, item_id, vote='up'):
         self.logged_in()


### PR DESCRIPTION
Currently the method report_gallery_item is not reporting post even though output returned is True. Two issues that could have caused this:
1) Imgur is currently not allowing reporting of posts via the API
2) Method define in imgurpython/client.py is outdated as the API documentation (https://api.imgur.com/endpoints/gallery#gallery-reporting) has defined a parameter reason. 
 I added the 'reason' parameter as part of this pull request. But even with the changes, the reporting of a gallery item does not work. 
3) In the API documentation, the parameter 'reason' is defined as optional while in the imugr web app, when you try to report a post, it asks you to select a reason which means it is mandatory. There is discrepancy there too