### PR TITLE
Add upload_from_file() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Examples can be found [here](EXAMPLES.md)
 ### Image
 
 * `get_image(image_id)`
+* `upload_from_file(file, config=None, anon=True)`
 * `upload_from_path(path, config=None, anon=True)`
 * `upload_from_url(url, config=None, anon=True)`
 * `delete_image(image_id)`

--- a/imgurpython/client.py
+++ b/imgurpython/client.py
@@ -579,21 +579,23 @@ class ImgurClient(object):
         image = self.make_request('GET', 'image/%s' % image_id)
         return Image(image)
 
-    def upload_from_path(self, path, config=None, anon=True):
+    def upload_from_file(self, file, config=None, anon=True):
         if not config:
             config = dict()
 
-        fd = open(path, 'rb')
-        contents = fd.read()
+        contents = file.read()
         b64 = base64.b64encode(contents)
         data = {
             'image': b64,
             'type': 'base64',
         }
         data.update({meta: config[meta] for meta in set(self.allowed_image_fields).intersection(config.keys())})
-        fd.close()
-        
+
         return self.make_request('POST', 'upload', data, anon)
+
+    def upload_from_path(self, path, config=None, anon=True):
+        with open(path, 'rb') as f:
+            return self.upload_from_file(f, config=config, anon=anon)
 
     def upload_from_url(self, url, config=None, anon=True):
         if not config:


### PR DESCRIPTION
This patch adds `upload_from_file()` method which takes an arbitrary readable [file object][1] and uploads it to imgur.  It’s a more generalized version of `upload_from_path()`.  It’s useful when the image binary isn’t stored to file but in the memory e.g. through `io.BytesIO` object.

[1]: https://docs.python.org/3/glossary.html#term-file-object