### PR TITLE
return upload information

### DIFF
--- a/imgurpython/client.py
+++ b/imgurpython/client.py
@@ -581,7 +581,7 @@ class ImgurClient(object):
 
     def upload_from_path(self, path, config=None, anon=True):
         with open(path, 'rb') as fd:
-            self.upload(fd, config, anon)
+            return self.upload(fd, config, anon)
 
     def upload(self, fd, config=None, anon=True):
         if not config:


### PR DESCRIPTION
now, 'upload_from_path' func on client.py did not return image upload result
information. but user need to it. then just return about upload
infomation after call 'upload' func