### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ Error types
 ```python
 from imgurpython.helpers.error import ImgurClientError
 
-try
+try:
     ...
-except ImgurClientError as e
+except ImgurClientError as e:
     print(e.error_message)
     print(e.status_code)
 ```


### PR DESCRIPTION
Added indents, 
so a SyntaxError `(SyntaxError: invalid syntax)` wouldn't be raised